### PR TITLE
Fix chapter 8 - NoMethodError undefined method products

### DIFF
--- a/rails6/en/chapter08-improve-orders.adoc
+++ b/rails6/en/chapter08-improve-orders.adoc
@@ -148,7 +148,7 @@ First we update the `orders_controller_test` file:
 # ...
 class Api::V1::OrdersControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @order = products(:one)
+    @order = orders(:one)
     @order_params = {
       order: {
         product_ids_and_quantities: [

--- a/rails6/es/chapter08-improve-orders.adoc
+++ b/rails6/es/chapter08-improve-orders.adoc
@@ -149,7 +149,7 @@ Primero actualizamos el archivo `orders_controller_test`:
 # ...
 class Api::V1::OrdersControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @order = products(:one)
+    @order = orders(:one)
     @order_params = {
       order: {
         product_ids_and_quantities: [

--- a/rails6/fr/chapter08-improve-orders.adoc
+++ b/rails6/fr/chapter08-improve-orders.adoc
@@ -144,7 +144,7 @@ Tout d'abord, nous mettons à jour le fichier `orders_controller_test`:
 # ...
 class Api::V1::OrdersControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @order = products(:one)
+    @order = orders(:one)
     @order_params = {
       order: {
         product_ids_and_quantities: [


### PR DESCRIPTION
I got stuck on Chapter 08. On the "Decrementing product quantity" section. I was entering the listing 124


```ruby
# ...
class Api::V1::OrdersControllerTest < ActionDispatch::IntegrationTest
  setup do
    @order = orders(:one)    # <=== BAD
    @order_params = {
      order: {
        product_ids_and_quantities: [
          { product_id: products(:one).id, quantity: 2 },
          { product_id: products(:two).id, quantity: 3 },
        ]
      }
    }
  end

```

Which caused the error:

```ruby
Error:
Api::V1::OrdersControllerTest#test_should_show_order:
NoMethodError: undefined method `products' for #<Product:0x00007facf60cac10>
    test/controllers/api/v1/orders_controller_test.rb:45:in `block in <class:OrdersControllerTest>'
```

I changed `@order = products(:one) `to` @order = orders(:one)` and it all worked again. This PR is the fix.