### PR TITLE
Fix warning in Ch08 - Validate quantity of products

### DIFF
--- a/rails6/en/chapter08-improve-orders.adoc
+++ b/rails6/en/chapter08-improve-orders.adoc
@@ -383,7 +383,7 @@ class EnoughProductsValidator < ActiveModel::Validator
     record.placements.each do |placement|
       product = placement.product
       if placement.quantity > product.quantity
-        record.errors[product.title.to_s] << "Is out of stock, just #{product.quantity} left"
+        record.errors.add product.title,  "Is out of stock, just #{product.quantity} left"
       end
     end
   end

--- a/rails6/es/chapter08-improve-orders.adoc
+++ b/rails6/es/chapter08-improve-orders.adoc
@@ -382,7 +382,7 @@ class EnoughProductsValidator < ActiveModel::Validator
     record.placements.each do |placement|
       product = placement.product
       if placement.quantity > product.quantity
-        record.errors[product.title.to_s] << "Is out of stock, just #{product.quantity} left"
+        record.errors.add product.title,  "Is out of stock, just #{product.quantity} left"
       end
     end
   end

--- a/rails6/fr/chapter08-improve-orders.adoc
+++ b/rails6/fr/chapter08-improve-orders.adoc
@@ -378,7 +378,7 @@ class EnoughProductsValidator < ActiveModel::Validator
     record.placements.each do |placement|
       product = placement.product
       if placement.quantity > product.quantity
-        record.errors[product.title.to_s] << "Is out of stock, just #{product.quantity} left"
+        record.errors.add product.title,  "Is out of stock, just #{product.quantity} left"
       end
     end
   end


### PR DESCRIPTION
### Section: Validate quantity of products

The book code listing for the validator causes a warning in Rails 6.1. The suggested warning fix, method add, has worked since Rails 3. 

```ruby
app/validators/enough_products_validator.rb
class EnoughProductsValidator < ActiveModel::Validator
  def validate(record)
    record.placements.each do |placement|
      product = placement.product
      if placement.quantity > product.quantity
        # ****************************** << deprecated in 6.1 ********************
        record.errors[product.title.to_s] << "Is out of stock, just #{product.quantity} left"    
      end
    end
  end
end
```

This generates the following warning:

```ruby
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. 
Please call `ActiveModel::Errors#add` instead. 
(called from block in validate at ... market_place_api/app/validators/enough_products_validator.rb:6)
```

You can fix this by changing errors method  << to add. Add has been available since 3.0 and is the suggested change in 6.1 so this change works with the current code and future proofs the book.


```ruby
record.errors.add product.title,  "Is out of stock, just #{product.quantity} left"
```
