### PR TITLE
Change text to match 'belongs_to' generator change

### DIFF
--- a/rails6/en/chapter07-placing-orders.adoc
+++ b/rails6/en/chapter07-placing-orders.adoc
@@ -34,7 +34,7 @@ Let’s start by creating the older model with a special form:
 $ rails generate model order user:belongs_to total:decimal
 ----
 
-The command above will generate the order model, but I’m taking advantage of the `references` method to create the corresponding foreign key for the order to belong to a user. It also adds the `belongs_to` directive into the order model. Let’s migrate the database.
+The command above will generate the order model, but I’m taking advantage of the `belongs_to` column type to create the corresponding foreign key for the order to belong to a user. It also adds the `belongs_to` association into the order model. Let’s migrate the database.
 
 [source,bash]
 ----
@@ -139,7 +139,7 @@ end
 ----
 
 
-If you have been following the tutorial so far, the implementation is already there because of the `references` type we pass on the model command generator. We should add `inverse_of` option to the `placement` model for each `belongs_to` call. This gives a little boost when referencing the parent object.
+If you have been following the tutorial so far, the implementation is already there because of the `belongs_to` column type we pass on the model command generator. We should add `inverse_of` option to the `placement` model for each `belongs_to` call. This gives a little boost when referencing the parent object.
 
 [source,ruby]
 .app/models/placement.rb


### PR DESCRIPTION
 - fix - references was changed to belongs_to but the surrounding
   text was not updated
 - change 'method' to 'column type'
 - 'directive' to the more specific 'association'

----

With regards to 'column type' change. I read the Rails guide to see what they called it:


[Also, the generator accepts column type as references (also available as belongs_to).](https://guides.rubyonrails.org/active_record_migrations.html)

---
I wasn't confident enough to change the French and Spanish versions.
