### PR TITLE
Unecessary change in the Serializer

### DIFF
--- a/rails6/fr/chapter06-improve-json.adoc
+++ b/rails6/fr/chapter06-improve-json.adoc
@@ -563,17 +563,6 @@ Et voilà. Maintenant voilà à quoi le JSON devrait ressembler:
 }
 ----
 
-L'implémentation est très simple: il suffit d'ajouter une ligne au sérialiseur du produit:
-
-[source,ruby]
-.app/serializers/product_serializer.rb
-----
-class ProductSerializer < ActiveModel::Serializer
-  attributes :id, :title, :price, :published
-  has_one :user
-end
-----
-
 Maintenant, tous les tests devraient passer:
 
 [source,bash]


### PR DESCRIPTION
tests passed already, this change in the serializer made actually the tests failed.  + `include FastJsonapi::ObjectSerializer` is missing.

I think we can remove this section, but I let you double check this part.