### PR TITLE
Fix missing definition of products in test setup

### DIFF
--- a/rails6/fr/chapter07-placing-orders.adoc
+++ b/rails6/fr/chapter07-placing-orders.adoc
@@ -468,6 +468,8 @@ class OrderTest < ActiveSupport::TestCase
 
   setup do
     @order = orders(:one)
+    @product1 = products(:one)
+    @product2 = products(:two)
   end
 
   test 'Should set total' do


### PR DESCRIPTION
add 
```
@product1 = products(:one)
@product2 = products(:two)```
in setup of model/order_test.rb
otherwise test does not work